### PR TITLE
Add readonly mode support with command line argument parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ With powerful tools and intuitive APIs, you can observe and control all your clu
 
 - 🔄 Supports **multi-cluster context switching**
 - 🔧 Enables **CRUD operations** on most common Kubernetes resources
+- 🔒 **Readonly mode** for safe cluster inspection
 - ⚙️ Powered by [MCP](https://modelcontextprotocol.io/) for Claude AI and beyond
 
 ---
@@ -46,6 +47,53 @@ cd k8s-pilot
 uv run --with mcp[cli] mcp run k8s_pilot.py
 ```
 
+## Usage
+
+### Normal Mode (Full Access)
+```bash
+# Start with full read/write access
+uv run --with mcp[cli] mcp run k8s_pilot.py
+```
+
+### Readonly Mode (Safe Inspection)
+```bash
+# Start in readonly mode - only read operations allowed
+uv run --with mcp[cli] python k8s_pilot.py --readonly
+```
+
+### Command Line Options
+```bash
+# Show help
+uv run --with mcp[cli] python k8s_pilot.py --help
+```
+
+## Readonly Mode
+
+The `--readonly` flag enables a safety mode that prevents any write operations to your Kubernetes clusters. This is perfect for:
+
+- **Cluster inspection** without risk of accidental changes
+- **Audit scenarios** where you need to view but not modify
+- **Learning environments** where you want to explore safely
+- **Production monitoring** with zero risk of modifications
+
+### Protected Operations (Blocked in Readonly Mode)
+- `pod_create`, `pod_update`, `pod_delete`
+- `deployment_create`, `deployment_update`, `deployment_delete`
+- `service_create`, `service_update`, `service_delete`
+- `configmap_create`, `configmap_update`, `configmap_delete`
+- `secret_create`, `secret_update`, `secret_delete`
+- `namespace_create`, `namespace_delete`
+- All other create/update/delete operations
+
+### Allowed Operations (Always Available)
+- `pod_list`, `pod_detail`, `pod_logs`
+- `deployment_list`, `deployment_get`
+- `service_list`, `service_get`
+- `configmap_list`, `configmap_get`
+- `secret_list`, `secret_get`
+- `namespace_list`, `namespace_get`
+- All other list/get operations
+
 ## Usage with Claude Desktop
 
 Use this config to run k8s_pilot MCP server from within Claude:
@@ -64,6 +112,28 @@ Use this config to run k8s_pilot MCP server from within Claude:
         "mcp",
         "run",
         "k8s_pilot.py"
+      ]
+    }
+  }
+}
+```
+
+For readonly mode, use this configuration:
+
+```json
+{
+  "mcpServers": {
+    "k8s_pilot_readonly": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "<path-to-cloned-repo>/k8s-pilot",
+        "run",
+        "--with",
+        "mcp[cli]",
+        "python",
+        "k8s_pilot.py",
+        "--readonly"
       ]
     }
   }

--- a/core/config.py
+++ b/core/config.py
@@ -1,0 +1,27 @@
+import argparse
+
+# Global readonly state
+_readonly_mode: bool = False
+
+def parse_arguments() -> None:
+    """Parse command line arguments and set global configuration."""
+    global _readonly_mode
+    
+    parser = argparse.ArgumentParser(description='K8s Pilot - Kubernetes management tool')
+    parser.add_argument('--readonly', action='store_true', 
+                       help='Enable readonly mode - only allow read/get operations')
+    
+    # Parse arguments from sys.argv
+    args, unknown = parser.parse_known_args()
+    
+    _readonly_mode = args.readonly
+
+
+def is_readonly_mode() -> bool:
+    """Check if readonly mode is enabled."""
+    return _readonly_mode
+
+
+def get_readonly_mode() -> bool:
+    """Get the current readonly mode setting."""
+    return _readonly_mode 

--- a/core/permissions.py
+++ b/core/permissions.py
@@ -1,0 +1,36 @@
+import functools
+from typing import Callable, Any
+from core.config import is_readonly_mode
+
+
+def check_readonly_permission(func: Callable) -> Callable:
+    """
+    Decorator to check if an operation is allowed in readonly mode.
+    
+    This decorator should be applied to all write operations (create, update, delete).
+    In readonly mode, these operations will raise a PermissionError.
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs) -> Any:
+        if is_readonly_mode():
+            operation_name = func.__name__
+            raise PermissionError(
+                f"Operation '{operation_name}' is not allowed in readonly mode. "
+                f"Only read/get operations are permitted when --readonly flag is used."
+            )
+        return func(*args, **kwargs)
+    return wrapper
+
+
+def is_write_operation(func_name: str) -> bool:
+    """
+    Check if a function name represents a write operation.
+    
+    Args:
+        func_name: The name of the function to check
+        
+    Returns:
+        True if the function is a write operation, False otherwise
+    """
+    write_operations = ['create', 'update', 'delete', 'patch', 'replace']
+    return any(op in func_name.lower() for op in write_operations) 

--- a/k8s_pilot.py
+++ b/k8s_pilot.py
@@ -1,4 +1,9 @@
+from core.config import parse_arguments
 from server.server import mcp  # noqa: F401
 
 if __name__ == "__main__":
+    # Parse command line arguments first
+    parse_arguments()
+    
+    # Start the MCP server
     mcp.run(transport='stdio')

--- a/tools/configmap.py
+++ b/tools/configmap.py
@@ -1,4 +1,5 @@
 from core.context import use_current_context
+from core.permissions import check_readonly_permission
 from core.kubeconfig import get_api_clients
 from server.server import mcp
 from kubernetes.client import CoreV1Api
@@ -25,6 +26,7 @@ def configmap_list(context_name: str, namespace: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def configmap_create(context_name: str, namespace: str, name: str, data: dict):
     """
     Create a ConfigMap in the specified namespace.
@@ -70,6 +72,7 @@ def configmap_get(context_name: str, namespace: str, name: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def configmap_update(context_name: str, namespace: str, name: str, data: dict):
     """
     Update an existing ConfigMap in the specified namespace.
@@ -92,6 +95,7 @@ def configmap_update(context_name: str, namespace: str, name: str, data: dict):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def configmap_delete(context_name: str, namespace: str, name: str):
     """
     Delete a ConfigMap from the specified namespace.

--- a/tools/daemonset.py
+++ b/tools/daemonset.py
@@ -2,6 +2,7 @@ from kubernetes.client import AppsV1Api, V1DaemonSet, V1ObjectMeta, V1PodTemplat
 from core.context import use_current_context
 from core.kubeconfig import get_api_clients
 from server.server import mcp
+from core.permissions import check_readonly_permission
 
 
 @mcp.tool()
@@ -25,6 +26,7 @@ def daemonset_list(context_name: str, namespace: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def daemonset_create(context_name: str, namespace: str, name: str, image: str, labels: dict):
     """
     Create a DaemonSet in the specified namespace.
@@ -75,6 +77,7 @@ def daemonset_get(context_name: str, namespace: str, name: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def daemonset_update(context_name: str, namespace: str, name: str, image: str):
     """
     Update an existing DaemonSet in the specified namespace.
@@ -97,6 +100,7 @@ def daemonset_update(context_name: str, namespace: str, name: str, image: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def daemonset_delete(context_name: str, namespace: str, name: str):
     """
     Delete a DaemonSet from the specified namespace.

--- a/tools/deployment.py
+++ b/tools/deployment.py
@@ -1,5 +1,6 @@
 from kubernetes.client import AppsV1Api, V1Deployment, V1ObjectMeta, V1PodTemplateSpec, V1PodSpec, V1Container, V1LabelSelector
 from core.context import use_current_context
+from core.permissions import check_readonly_permission
 from core.kubeconfig import get_api_clients
 from server.server import mcp
 
@@ -25,6 +26,7 @@ def deployment_list(context_name: str, namespace: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def deployment_create(context_name: str, namespace: str, name: str, image: str, replicas: int, labels: dict):
     """
     Create a Deployment in the specified namespace.
@@ -82,6 +84,7 @@ def deployment_get(context_name: str, namespace: str, name: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def deployment_update(context_name: str, namespace: str, name: str, image: str, replicas: int):
     """
     Update an existing Deployment in the specified namespace.
@@ -106,6 +109,7 @@ def deployment_update(context_name: str, namespace: str, name: str, image: str, 
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def deployment_delete(context_name: str, namespace: str, name: str):
     """
     Delete a Deployment from the specified namespace.

--- a/tools/ingress.py
+++ b/tools/ingress.py
@@ -3,6 +3,7 @@ from kubernetes.client import NetworkingV1Api, V1Ingress, V1ObjectMeta, V1Ingres
 from core.context import use_current_context
 from core.kubeconfig import get_api_clients
 from server.server import mcp
+from core.permissions import check_readonly_permission
 
 
 @mcp.tool()
@@ -26,6 +27,7 @@ def ingress_list(context_name: str, namespace: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def ingress_create(context_name: str, namespace: str, name: str, host: str, service_name: str, service_port: int):
     """
     Create an Ingress in the specified namespace.
@@ -99,6 +101,7 @@ def ingress_get(context_name: str, namespace: str, name: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def ingress_update(context_name: str, namespace: str, name: str, host: str, service_name: str, service_port: int):
     """
     Update an existing Ingress in the specified namespace.
@@ -125,6 +128,7 @@ def ingress_update(context_name: str, namespace: str, name: str, host: str, serv
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def ingress_delete(context_name: str, namespace: str, name: str):
     """
     Delete an Ingress from the specified namespace.

--- a/tools/namespace.py
+++ b/tools/namespace.py
@@ -5,6 +5,7 @@ from kubernetes.client import CoreV1Api, V1Namespace, V1ObjectMeta
 from kubernetes.client.rest import ApiException
 
 from core.context import use_current_context
+from core.permissions import check_readonly_permission
 from core.kubeconfig import get_api_clients
 from server.server import mcp
 
@@ -65,6 +66,7 @@ def get_namespace_details(context_name: str, namespace: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def create_namespace(context_name: str, namespace: str, labels: Optional[Dict[str, str]] = None):
     """
     Create a new namespace.
@@ -110,6 +112,7 @@ def create_namespace(context_name: str, namespace: str, labels: Optional[Dict[st
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def delete_namespace(context_name: str, namespace: str):
     """
     Delete a namespace and all resources within it.
@@ -149,6 +152,7 @@ def delete_namespace(context_name: str, namespace: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def add_namespace_label(context_name: str, namespace: str, label_key: str, label_value: str):
     """
     Add or update a label on a namespace.
@@ -200,6 +204,7 @@ def add_namespace_label(context_name: str, namespace: str, label_key: str, label
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def remove_namespace_label(context_name: str, namespace: str, label_key: str):
     """
     Remove a label from a namespace.
@@ -331,6 +336,7 @@ def list_namespace_resources(context_name: str, namespace: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def set_namespace_resource_quota(context_name: str, namespace: str,
                                  cpu_limit: Optional[str] = None,
                                  memory_limit: Optional[str] = None,

--- a/tools/pod.py
+++ b/tools/pod.py
@@ -1,6 +1,7 @@
 from typing import Optional, Dict, List
 
 from core.context import use_current_context
+from core.permissions import check_readonly_permission
 from server.server import mcp
 from kubernetes.client import CoreV1Api
 from core.kubeconfig import get_api_clients
@@ -174,6 +175,7 @@ def pod_detail(context_name: str, namespace: str, name: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def pod_create(context_name: str, namespace: str, name: str, image: str,
                labels: Optional[Dict[str, str]] = None,
                command: Optional[List[str]] = None,
@@ -240,6 +242,7 @@ def pod_create(context_name: str, namespace: str, name: str, image: str,
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def pod_update(context_name: str, namespace: str, name: str,
                labels: Optional[Dict[str, str]] = None):
     """
@@ -281,6 +284,7 @@ def pod_update(context_name: str, namespace: str, name: str,
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def pod_delete(context_name: str, namespace: str, name: str):
     """
     Delete a pod from the specified namespace.

--- a/tools/pv.py
+++ b/tools/pv.py
@@ -2,6 +2,7 @@ from kubernetes.client import CoreV1Api, V1PersistentVolume, V1ObjectMeta, V1Per
 from core.context import use_current_context
 from core.kubeconfig import get_api_clients
 from server.server import mcp
+from core.permissions import check_readonly_permission
 
 
 @mcp.tool()
@@ -24,6 +25,7 @@ def pv_list(context_name: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def pv_create(context_name: str, name: str, capacity: str, access_modes: list, storage_class: str, host_path: str):
     """
     Create a PersistentVolume in the cluster.
@@ -79,6 +81,7 @@ def pv_get(context_name: str, name: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def pv_update(context_name: str, name: str, labels: dict):
     """
     Update an existing PersistentVolume's metadata (e.g., labels).
@@ -100,6 +103,7 @@ def pv_update(context_name: str, name: str, labels: dict):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def pv_delete(context_name: str, name: str):
     """
     Delete a PersistentVolume from the cluster.

--- a/tools/pvc.py
+++ b/tools/pvc.py
@@ -2,6 +2,7 @@ from kubernetes.client import CoreV1Api, V1PersistentVolumeClaim, V1ObjectMeta, 
 from core.context import use_current_context
 from core.kubeconfig import get_api_clients
 from server.server import mcp
+from core.permissions import check_readonly_permission
 
 
 @mcp.tool()
@@ -25,6 +26,7 @@ def pvc_list(context_name: str, namespace: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def pvc_create(context_name: str, namespace: str, name: str, storage: str, access_modes: list, storage_class: str = None):
     """
     Create a PersistentVolumeClaim in the specified namespace.
@@ -80,6 +82,7 @@ def pvc_get(context_name: str, namespace: str, name: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def pvc_update(context_name: str, namespace: str, name: str, labels: dict):
     """
     Update an existing PersistentVolumeClaim's metadata (e.g., labels).
@@ -102,6 +105,7 @@ def pvc_update(context_name: str, namespace: str, name: str, labels: dict):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def pvc_delete(context_name: str, namespace: str, name: str):
     """
     Delete a PersistentVolumeClaim from the specified namespace.

--- a/tools/replicaset.py
+++ b/tools/replicaset.py
@@ -1,5 +1,6 @@
 from kubernetes.client import AppsV1Api, V1ReplicaSet, V1ObjectMeta, V1PodTemplateSpec, V1PodSpec, V1Container, V1LabelSelector
 from core.context import use_current_context
+from core.permissions import check_readonly_permission
 from core.kubeconfig import get_api_clients
 from server.server import mcp
 
@@ -25,6 +26,7 @@ def replicaset_list(context_name: str, namespace: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def replicaset_create(context_name: str, namespace: str, name: str, image: str, replicas: int, labels: dict):
     """
     Create a ReplicaSet in the specified namespace.
@@ -82,6 +84,7 @@ def replicaset_get(context_name: str, namespace: str, name: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def replicaset_update(context_name: str, namespace: str, name: str, image: str, replicas: int):
     """
     Update an existing ReplicaSet in the specified namespace.
@@ -106,6 +109,7 @@ def replicaset_update(context_name: str, namespace: str, name: str, image: str, 
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def replicaset_delete(context_name: str, namespace: str, name: str):
     """
     Delete a ReplicaSet from the specified namespace.

--- a/tools/role.py
+++ b/tools/role.py
@@ -2,6 +2,7 @@ from kubernetes.client import RbacAuthorizationV1Api, V1Role, V1ClusterRole, V1O
 from core.context import use_current_context
 from core.kubeconfig import get_api_clients
 from server.server import mcp
+from core.permissions import check_readonly_permission
 
 
 @mcp.tool()
@@ -25,6 +26,7 @@ def role_list(context_name: str, namespace: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def role_create(context_name: str, namespace: str, name: str, rules: list):
     """
     Create a Role in the specified namespace.
@@ -71,6 +73,7 @@ def role_get(context_name: str, namespace: str, name: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def role_delete(context_name: str, namespace: str, name: str):
     """
     Delete a Role from the specified namespace.
@@ -108,6 +111,7 @@ def clusterrole_list(context_name: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def clusterrole_create(context_name: str, name: str, rules: list):
     """
     Create a ClusterRole in the cluster.
@@ -152,6 +156,7 @@ def clusterrole_get(context_name: str, name: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def clusterrole_delete(context_name: str, name: str):
     """
     Delete a ClusterRole from the cluster.

--- a/tools/secret.py
+++ b/tools/secret.py
@@ -2,6 +2,7 @@ from kubernetes.client import CoreV1Api, V1Secret, V1ObjectMeta
 from core.context import use_current_context
 from core.kubeconfig import get_api_clients
 from server.server import mcp
+from core.permissions import check_readonly_permission
 import base64
 
 
@@ -26,6 +27,7 @@ def secret_list(context_name: str, namespace: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def secret_create(context_name: str, namespace: str, name: str, data: dict, secret_type: str = "Opaque"):
     """
     Create a Secret in the specified namespace.
@@ -77,6 +79,7 @@ def secret_get(context_name: str, namespace: str, name: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def secret_update(context_name: str, namespace: str, name: str, data: dict):
     """
     Update an existing Secret in the specified namespace.
@@ -100,6 +103,7 @@ def secret_update(context_name: str, namespace: str, name: str, data: dict):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def secret_delete(context_name: str, namespace: str, name: str):
     """
     Delete a Secret from the specified namespace.

--- a/tools/service.py
+++ b/tools/service.py
@@ -2,6 +2,7 @@ from kubernetes.client import CoreV1Api, V1Service, V1ObjectMeta, V1ServiceSpec,
 from core.context import use_current_context
 from core.kubeconfig import get_api_clients
 from server.server import mcp
+from core.permissions import check_readonly_permission
 
 
 @mcp.tool()
@@ -25,6 +26,7 @@ def service_list(context_name: str, namespace: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def service_create(context_name: str, namespace: str, name: str, selector: dict, ports: list, service_type: str = "ClusterIP"):
     """
     Create a Service in the specified namespace.
@@ -80,6 +82,7 @@ def service_get(context_name: str, namespace: str, name: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def service_update(context_name: str, namespace: str, name: str, labels: dict):
     """
     Update an existing Service's metadata (e.g., labels).
@@ -102,6 +105,7 @@ def service_update(context_name: str, namespace: str, name: str, labels: dict):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def service_delete(context_name: str, namespace: str, name: str):
     """
     Delete a Service from the specified namespace.

--- a/tools/serviceaccount.py
+++ b/tools/serviceaccount.py
@@ -2,6 +2,7 @@ from kubernetes.client import CoreV1Api, V1ServiceAccount, V1ObjectMeta
 from core.context import use_current_context
 from core.kubeconfig import get_api_clients
 from server.server import mcp
+from core.permissions import check_readonly_permission
 
 
 @mcp.tool()
@@ -25,6 +26,7 @@ def serviceaccount_list(context_name: str, namespace: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def serviceaccount_create(context_name: str, namespace: str, name: str, labels: dict = None):
     """
     Create a ServiceAccount in the specified namespace.
@@ -71,6 +73,7 @@ def serviceaccount_get(context_name: str, namespace: str, name: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def serviceaccount_delete(context_name: str, namespace: str, name: str):
     """
     Delete a ServiceAccount from the specified namespace.

--- a/tools/statefulset.py
+++ b/tools/statefulset.py
@@ -1,5 +1,6 @@
 from kubernetes.client import AppsV1Api, V1StatefulSet, V1ObjectMeta, V1LabelSelector, V1PodTemplateSpec, V1PodSpec, V1Container, V1StatefulSetSpec
 from core.context import use_current_context
+from core.permissions import check_readonly_permission
 from core.kubeconfig import get_api_clients
 from server.server import mcp
 
@@ -25,6 +26,7 @@ def statefulset_list(context_name: str, namespace: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def statefulset_create(context_name: str, namespace: str, name: str, image: str, replicas: int, labels: dict):
     """
     Create a StatefulSet in the specified namespace.
@@ -83,6 +85,7 @@ def statefulset_get(context_name: str, namespace: str, name: str):
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def statefulset_update(context_name: str, namespace: str, name: str, image: str, replicas: int):
     """
     Update an existing StatefulSet in the specified namespace.
@@ -107,6 +110,7 @@ def statefulset_update(context_name: str, namespace: str, name: str, image: str,
 
 @mcp.tool()
 @use_current_context
+@check_readonly_permission
 def statefulset_delete(context_name: str, namespace: str, name: str):
     """
     Delete a StatefulSet from the specified namespace.


### PR DESCRIPTION
- Introduced `--readonly` flag to enable safe inspection mode, preventing write operations.
- Added `parse_arguments` function in `core/config.py` to handle command line arguments.
- Implemented `check_readonly_permission` decorator in `core/permissions.py` to restrict write operations when readonly mode is active.
- Updated `k8s_pilot.py` to parse arguments before starting the MCP server.
- Enhanced documentation in `README.md` to include usage instructions for readonly mode.