### PR TITLE
ci: Add GitHub Actions for Linting and Docker Build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,51 @@
+name: Docker Build and Publish
+
+on:
+  push:
+    branches: [ "main" ]
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,30 @@
+name: Lint and Type Check
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: "pyproject.toml"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run Ruff Linter
+        run: uv run ruff check .

--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ uv run --with "mcp[cli]>=1.28.0,<2" python k8s_pilot.py --transport streamable-h
 uv run --with "mcp[cli]>=1.28.0,<2" python k8s_pilot.py --help
 ```
 
+### Run via Docker
+You can run k8s-pilot directly using the published Docker image without installing `uv` locally. 
+Make sure to mount your `~/.kube/config` so the container can access your clusters.
+
+```bash
+docker run -i --rm \
+  -v ~/.kube/config:/root/.kube/config \
+  ghcr.io/bourbonkk/k8s-pilot:latest
+```
+
 ## Readonly Mode
 
 The `--readonly` flag enables a safety mode that prevents any write operations to your Kubernetes clusters. This is perfect for:
@@ -168,7 +178,27 @@ For readonly mode, use this configuration:
 }
 ```
 
-Replace <path-to-cloned-repo> with the actual directory where you cloned the repo.
+For Docker, use this configuration (replace `YOUR_USERNAME` with your actual Mac user name):
+
+```json
+{
+  "mcpServers": {
+    "k8s_pilot_docker": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-v",
+        "/Users/YOUR_USERNAME/.kube/config:/root/.kube/config",
+        "ghcr.io/bourbonkk/k8s-pilot:latest"
+      ]
+    }
+  }
+}
+```
+
+Replace `<path-to-cloned-repo>` with the actual directory where you cloned the repo.
 
 ## Scenario
 Create a Deployment using the nginx:latest image in the pypy namespace, and also create a Service that connects to it.

--- a/tools/deployment.py
+++ b/tools/deployment.py
@@ -55,9 +55,11 @@ async def deployment_create(context_name: str, namespace: str, name: str, image:
             )
         }
     )
-    if ctx: await ctx.info(f"Creating deployment '{name}' in namespace '{namespace}'")
+    if ctx:
+        await ctx.info(f"Creating deployment '{name}' in namespace '{namespace}'")
     created_deployment = apps_v1.create_namespaced_deployment(namespace=namespace, body=deployment)
-    if ctx: await ctx.info(f"Successfully created deployment '{name}'")
+    if ctx:
+        await ctx.info(f"Successfully created deployment '{name}'")
     return {"name": created_deployment.metadata.name, "status": "Created"}
 
 
@@ -106,9 +108,11 @@ async def deployment_update(context_name: str, namespace: str, name: str, image:
     deployment = apps_v1.read_namespaced_deployment(name=name, namespace=namespace)
     deployment.spec.template.spec.containers[0].image = image
     deployment.spec.replicas = replicas
-    if ctx: await ctx.info(f"Updating deployment '{name}' in namespace '{namespace}'")
+    if ctx:
+        await ctx.info(f"Updating deployment '{name}' in namespace '{namespace}'")
     updated_deployment = apps_v1.replace_namespaced_deployment(name=name, namespace=namespace, body=deployment)
-    if ctx: await ctx.info(f"Successfully updated deployment '{name}'")
+    if ctx:
+        await ctx.info(f"Successfully updated deployment '{name}'")
     return {"name": updated_deployment.metadata.name, "status": "Updated"}
 
 
@@ -128,7 +132,9 @@ async def deployment_delete(context_name: str, namespace: str, name: str, ctx: C
         Status of the deletion operation
     """
     apps_v1: AppsV1Api = get_api_clients(context_name)["apps"]
-    if ctx: await ctx.warning(f"Deleting deployment '{name}' from namespace '{namespace}'")
+    if ctx:
+        await ctx.warning(f"Deleting deployment '{name}' from namespace '{namespace}'")
     apps_v1.delete_namespaced_deployment(name=name, namespace=namespace)
-    if ctx: await ctx.info(f"Successfully deleted deployment '{name}'")
+    if ctx:
+        await ctx.info(f"Successfully deleted deployment '{name}'")
     return {"name": name, "status": "Deleted"}

--- a/tools/namespace.py
+++ b/tools/namespace.py
@@ -397,7 +397,7 @@ async def set_namespace_resource_quota(context_name: str, namespace: str,
 
         # Check if quota already exists
         try:
-            existing_quota = core_v1.read_namespaced_resource_quota(quota_name, namespace)
+            core_v1.read_namespaced_resource_quota(quota_name, namespace)
             # Update existing quota
             body = {
                 "spec": {

--- a/tools/pod.py
+++ b/tools/pod.py
@@ -307,7 +307,8 @@ async def pod_delete(context_name: str, namespace: str, name: str, ctx: Context 
     core_v1: CoreV1Api = get_api_clients(context_name)["core"]
 
     try:
-        if ctx: await ctx.warning(f"Deleting pod '{name}' from namespace '{namespace}'")
+        if ctx:
+            await ctx.warning(f"Deleting pod '{name}' from namespace '{namespace}'")
         # Delete the pod
         api_response = core_v1.delete_namespaced_pod(
             name=name,
@@ -317,7 +318,8 @@ async def pod_delete(context_name: str, namespace: str, name: str, ctx: Context 
 
         # Check if the response indicates success
         if api_response.status == "Success":
-            if ctx: await ctx.info(f"Successfully deleted pod '{name}'")
+            if ctx:
+                await ctx.info(f"Successfully deleted pod '{name}'")
             return {
                 "name": name,
                 "namespace": namespace,


### PR DESCRIPTION
## Changes
This PR introduces the first CI/CD pipelines for the project:

### 1. Python Linting (`lint.yml`)
- Runs `ruff check` on PRs and pushes to `main`.
- Uses `astral-sh/setup-uv` for fast environment setup and caching.

### 2. Docker Publish (`docker-publish.yml`)
- Automatically builds the `Dockerfile`.
- Publishes the built image to GitHub Container Registry (GHCR).
- Triggers on pushes to `main` (tags as `latest`) and on published GitHub Releases (tags with version).
- Utilizes Docker Buildx and GHA caching for faster builds.