### PR TITLE
test: Add Unit Tests and Pytest CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Lint and Type Check
+name: CI
 
 on:
   push:
@@ -28,3 +28,25 @@ jobs:
 
       - name: Run Ruff Linter
         run: uv run ruff check .
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: "pyproject.toml"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run Pytest
+        run: uv run pytest tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,10 @@ dependencies = [
 
 [tool.mcp]
 entrypoint = "k8s_pilot.py"
+
+[dependency-groups]
+dev = [
+    "pytest>=9.1.1",
+    "pytest-asyncio>=1.4.0",
+    "pytest-mock>=3.15.1",
+]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Empty init file

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,49 @@
+import sys
+from unittest.mock import patch
+from core import config
+
+
+def test_default_config():
+    """Test default values of configuration variables."""
+    assert config.get_readonly_mode() is False
+    assert config.get_transport() == 'stdio'
+
+
+def test_parse_arguments_readonly():
+    """Test parse_arguments with --readonly flag."""
+    test_args = ["k8s_pilot.py", "--readonly"]
+    with patch.object(sys, 'argv', test_args):
+        config.parse_arguments()
+        assert config.is_readonly_mode() is True
+        assert config.get_readonly_mode() is True
+        assert config.get_transport() == 'stdio'
+        
+    # Reset state for other tests
+    config._readonly_mode = False
+    config._transport = 'stdio'
+
+
+def test_parse_arguments_transport():
+    """Test parse_arguments with --transport flag."""
+    test_args = ["k8s_pilot.py", "--transport", "streamable-http"]
+    with patch.object(sys, 'argv', test_args):
+        config.parse_arguments()
+        assert config.is_readonly_mode() is False
+        assert config.get_transport() == 'streamable-http'
+        
+    # Reset state for other tests
+    config._readonly_mode = False
+    config._transport = 'stdio'
+
+
+def test_parse_arguments_both():
+    """Test parse_arguments with both flags."""
+    test_args = ["k8s_pilot.py", "--readonly", "--transport", "streamable-http"]
+    with patch.object(sys, 'argv', test_args):
+        config.parse_arguments()
+        assert config.is_readonly_mode() is True
+        assert config.get_transport() == 'streamable-http'
+        
+    # Reset state for other tests
+    config._readonly_mode = False
+    config._transport = 'stdio'

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,75 @@
+import pytest
+import asyncio
+from unittest.mock import patch
+from core import context
+
+
+@patch('core.context.config.list_kube_config_contexts')
+def test_get_current_context_name(mock_list_contexts):
+    """Test getting the current context name."""
+    mock_contexts = [{"name": "context1"}, {"name": "context2"}]
+    mock_active = {"name": "context1"}
+    mock_list_contexts.return_value = (mock_contexts, mock_active)
+    
+    result = context.get_current_context_name()
+    assert result == "context1"
+
+
+@patch('core.context.config.list_kube_config_contexts')
+def test_get_default_namespace_found(mock_list_contexts):
+    """Test getting the default namespace when specified in context."""
+    mock_contexts = [
+        {"name": "ctx1", "context": {"namespace": "custom-ns"}},
+        {"name": "ctx2", "context": {}}
+    ]
+    mock_list_contexts.return_value = (mock_contexts, None)
+    
+    result = context.get_default_namespace("ctx1")
+    assert result == "custom-ns"
+
+
+@patch('core.context.config.list_kube_config_contexts')
+def test_get_default_namespace_not_found(mock_list_contexts):
+    """Test getting default namespace fallback."""
+    mock_contexts = [{"name": "ctx2", "context": {}}]
+    mock_list_contexts.return_value = (mock_contexts, None)
+    
+    result = context.get_default_namespace("ctx2")
+    assert result == "default"
+
+
+@patch('core.context.get_current_context_name')
+@patch('core.context.get_default_namespace')
+def test_use_current_context_sync(mock_get_default_namespace, mock_get_context):
+    """Test decorator on a synchronous function."""
+    mock_get_context.return_value = "auto-context"
+    mock_get_default_namespace.return_value = "auto-namespace"
+    
+    @context.use_current_context
+    def dummy_func(context_name: str, namespace: str):
+        return context_name, namespace
+
+    # Test auto-injection when kwargs missing
+    assert dummy_func() == ("auto-context", "auto-namespace")
+    
+    # Test auto-injection when kwargs are None
+    assert dummy_func(context_name=None, namespace=None) == ("auto-context", "auto-namespace")
+    
+    # Test overriding values
+    assert dummy_func(context_name="manual-ctx", namespace="manual-ns") == ("manual-ctx", "manual-ns")
+
+
+@patch('core.context.get_current_context_name')
+@patch('core.context.get_default_namespace')
+@pytest.mark.asyncio
+async def test_use_current_context_async(mock_get_default_namespace, mock_get_context):
+    """Test decorator on an asynchronous function."""
+    mock_get_context.return_value = "async-auto-context"
+    mock_get_default_namespace.return_value = "async-auto-namespace"
+    
+    @context.use_current_context
+    async def dummy_async_func(context_name: str, namespace: str):
+        return context_name, namespace
+
+    # Test auto-injection
+    assert await dummy_async_func() == ("async-auto-context", "async-auto-namespace")

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,5 +1,4 @@
 import pytest
-import asyncio
 from unittest.mock import patch
 from core import context
 

--- a/tests/test_kubeconfig.py
+++ b/tests/test_kubeconfig.py
@@ -1,0 +1,77 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from core import kubeconfig
+import yaml
+import os
+
+
+@pytest.fixture(autouse=True)
+def clear_client_cache():
+    """Clear the client cache before and after each test."""
+    kubeconfig._client_cache.clear()
+    yield
+    kubeconfig._client_cache.clear()
+
+
+@patch('core.kubeconfig.config.load_kube_config')
+@patch('core.kubeconfig.client.ApiClient')
+@patch('core.kubeconfig.client.CoreV1Api')
+@patch('core.kubeconfig.client.AppsV1Api')
+@patch('core.kubeconfig.client.BatchV1Api')
+@patch('core.kubeconfig.client.NetworkingV1Api')
+@patch('core.kubeconfig.client.RbacAuthorizationV1Api')
+def test_get_api_clients_creates_new(
+    mock_rbac, mock_networking, mock_batch, mock_apps, mock_core, mock_api_client, mock_load_kube_config
+):
+    """Test that get_api_clients initializes and returns clients if not in cache."""
+    context_name = "minikube"
+    
+    clients = kubeconfig.get_api_clients(context_name)
+    
+    assert mock_load_kube_config.called
+    assert mock_api_client.called
+    assert mock_core.called
+    assert mock_apps.called
+    assert mock_batch.called
+    assert mock_networking.called
+    assert mock_rbac.called
+    
+    assert "core" in clients
+    assert "apps" in clients
+    assert "batch" in clients
+    assert "networking" in clients
+    assert "rbac" in clients
+    
+    # Check that it's in the cache now
+    assert context_name in kubeconfig._client_cache
+
+
+@patch('core.kubeconfig.config.load_kube_config')
+def test_get_api_clients_uses_cache(mock_load_kube_config):
+    """Test that get_api_clients returns from cache without reloading."""
+    context_name = "test-cluster"
+    
+    # Pre-populate cache
+    fake_clients = {"core": "fake-core-client"}
+    kubeconfig._client_cache[context_name] = fake_clients
+    
+    clients = kubeconfig.get_api_clients(context_name)
+    
+    # It should not call load_kube_config
+    assert not mock_load_kube_config.called
+    assert clients == fake_clients
+
+
+@patch('builtins.open')
+@patch('yaml.safe_load')
+@patch('os.path.expanduser')
+def test_get_kubeconfig(mock_expanduser, mock_safe_load, mock_open):
+    """Test get_kubeconfig loading the default file."""
+    mock_expanduser.return_value = "/path/to/fake/kube/config"
+    mock_safe_load.return_value = {"clusters": [], "contexts": []}
+    
+    result = kubeconfig.get_kubeconfig()
+    
+    mock_expanduser.assert_called_once()
+    mock_open.assert_called_once_with("/path/to/fake/kube/config", "r")
+    assert result == {"clusters": [], "contexts": []}

--- a/tests/test_kubeconfig.py
+++ b/tests/test_kubeconfig.py
@@ -1,8 +1,6 @@
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from core import kubeconfig
-import yaml
-import os
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,0 +1,73 @@
+import pytest
+from core.permissions import check_readonly_permission, is_write_operation
+from core import config
+
+
+@pytest.fixture(autouse=True)
+def reset_config_state():
+    """Ensure config state is reset before and after each test."""
+    config._readonly_mode = False
+    yield
+    config._readonly_mode = False
+
+
+def test_is_write_operation():
+    """Test the is_write_operation helper function."""
+    # Write operations
+    assert is_write_operation("pod_create") is True
+    assert is_write_operation("update_deployment") is True
+    assert is_write_operation("delete_namespace") is True
+    assert is_write_operation("patch_node") is True
+    assert is_write_operation("replace_secret") is True
+    
+    # Read operations
+    assert is_write_operation("get_pods") is False
+    assert is_write_operation("list_namespaces") is False
+    assert is_write_operation("describe_node") is False
+
+
+def test_check_readonly_permission_sync_allowed():
+    """Test that a sync function is allowed when readonly is False."""
+    @check_readonly_permission
+    def test_func():
+        return "success"
+        
+    config._readonly_mode = False
+    assert test_func() == "success"
+
+
+def test_check_readonly_permission_sync_blocked():
+    """Test that a sync function is blocked when readonly is True."""
+    @check_readonly_permission
+    def test_func():
+        return "success"
+        
+    config._readonly_mode = True
+    with pytest.raises(PermissionError) as exc_info:
+        test_func()
+    assert "not allowed in readonly mode" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_check_readonly_permission_async_allowed():
+    """Test that an async function is allowed when readonly is False."""
+    @check_readonly_permission
+    async def async_test_func():
+        return "success"
+        
+    config._readonly_mode = False
+    result = await async_test_func()
+    assert result == "success"
+
+
+@pytest.mark.asyncio
+async def test_check_readonly_permission_async_blocked():
+    """Test that an async function is blocked when readonly is True."""
+    @check_readonly_permission
+    async def async_test_func():
+        return "success"
+        
+    config._readonly_mode = True
+    with pytest.raises(PermissionError) as exc_info:
+        await async_test_func()
+    assert "not allowed in readonly mode" in str(exc_info.value)

--- a/tests/test_tools_pod.py
+++ b/tests/test_tools_pod.py
@@ -1,0 +1,45 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from tools import pod
+
+
+@pytest.fixture
+def mock_core_v1():
+    with patch('tools.pod.get_api_clients') as mock_get_clients:
+        mock_api = MagicMock()
+        mock_get_clients.return_value = {"core": mock_api}
+        yield mock_api
+
+
+def test_pod_list(mock_core_v1):
+    """Test pod_list functionality."""
+    # Setup mock response
+    mock_pod = MagicMock()
+    mock_pod.metadata.name = "test-pod-1"
+    mock_core_v1.list_namespaced_pod.return_value.items = [mock_pod]
+
+    result = pod.pod_list(context_name="ctx", namespace="default")
+    
+    assert len(result) == 1
+    assert result[0]["name"] == "test-pod-1"
+    mock_core_v1.list_namespaced_pod.assert_called_once_with("default")
+
+
+@pytest.mark.asyncio
+async def test_pod_delete(mock_core_v1):
+    """Test async pod_delete functionality."""
+    # Setup mock response
+    mock_response = MagicMock()
+    mock_response.status = "Success"
+    mock_core_v1.delete_namespaced_pod.return_value = mock_response
+
+    # Test without ctx to skip logging side-effects
+    result = await pod.pod_delete(context_name="ctx", namespace="default", name="target-pod")
+
+    assert result["status"] == "Deleted"
+    assert result["name"] == "target-pod"
+    mock_core_v1.delete_namespaced_pod.assert_called_once_with(
+        name="target-pod",
+        namespace="default",
+        body={}
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -311,6 +311,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -348,12 +357,26 @@ dependencies = [
     { name = "ruff" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-mock" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "kubernetes", specifier = ">=32.0.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.28.0,<2" },
     { name = "pyyaml" },
     { name = "ruff", specifier = ">=0.11.5" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0" },
+    { name = "pytest-mock", specifier = ">=3.15.1" },
 ]
 
 [[package]]
@@ -440,6 +463,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6d/fa/fbf4001037904031639e6bfbfc02badfc7e12f137a8afa254df6c4c8a670/oauthlib-3.2.2.tar.gz", hash = "sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918", size = 177352, upload-time = "2022-10-17T20:04:27.471Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/80/cab10959dc1faead58dc8384a781dfbf93cb4d33d50988f7a69f1b7c9bbe/oauthlib-3.2.2-py3-none-any.whl", hash = "sha256:8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca", size = 151688, upload-time = "2022-10-17T20:04:24.037Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -637,6 +678,46 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Changes
- Adds `pytest`, `pytest-asyncio`, and `pytest-mock` via `uv`.
- Implements unit tests for `core/config.py` and `core/permissions.py`.
- Renames `lint.yml` to `ci.yml` and adds a `test` job that runs `uv run pytest tests/`.