### PR TITLE
ci: Support linux/arm64 Docker Images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -37,6 +37,9 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=semver,pattern={{version}}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -45,6 +48,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
## Issue
Docker Desktop on Mac (Apple Silicon) fails to pull the image because the registry only contains a `linux/amd64` manifest.

## Changes
- Adds `docker/setup-qemu-action` for QEMU multi-architecture emulation.
- Updates `build-push-action` to build for both `linux/amd64` and `linux/arm64` platforms.